### PR TITLE
Improve windows advertisement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Improve Android connection
 - On Android, `isSupported` will return false if not supported instead of throwing error
 - Fix Windows `updateCharacteristic` API when deviceId is not null
-- Fix Windows `isAdvertising` and `isSupported` Api's
-- Improve Windows `addService` and `startAdvertising` Api's to match other platforms
+- Fix Windows `isAdvertising` and `isSupported` APIs
+- Improve Windows `addService` and `startAdvertising` APIs to match other platforms
 - Bump Pigeon Version
 
 ## 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Improve Android connection
 - On Android, `isSupported` will return false if not supported instead of throwing error
 - Fix Windows `updateCharacteristic` API when deviceId is not null
+- Fix Windows `isAdvertising` and `isSupported` Api's
+- Improve Windows `addService` and `startAdvertising` Api's to match other platforms
 - Bump Pigeon Version
 
 ## 2.4.0

--- a/example/lib/home_controller.dart
+++ b/example/lib/home_controller.dart
@@ -32,29 +32,6 @@ class HomeController extends GetxController {
         _ => "TestDevice"
       };
 
-  var manufacturerData = ManufacturerData(
-    manufacturerId: 0x012D,
-    data: Uint8List.fromList([
-      0x03,
-      0x00,
-      0x64,
-      0x00,
-      0x45,
-      0x31,
-      0x22,
-      0xAB,
-      0x00,
-      0x21,
-      0x60,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x00
-    ]),
-  );
-
   // Battery Service
   String serviceBattery = "0000180F-0000-1000-8000-00805F9B34FB";
   String characteristicBatteryLevel = "00002A19-0000-1000-8000-00805F9B34FB";
@@ -140,7 +117,10 @@ class HomeController extends GetxController {
     await BlePeripheral.startAdvertising(
       services: [serviceBattery, serviceTest],
       localName: deviceName,
-      manufacturerData: manufacturerData,
+      manufacturerData: ManufacturerData(
+        manufacturerId: 0x012D,
+        data: Uint8List.fromList([0x01, 0x02, 0x03]),
+      ),
       addManufacturerDataInScanResponse: true,
     );
   }

--- a/windows/ble_peripheral_plugin.cpp
+++ b/windows/ble_peripheral_plugin.cpp
@@ -208,17 +208,6 @@ namespace ble_peripheral
         return FlutterError("Already advertising");
       }
 
-      // Advertising with LocalName is not supported
-      // if (local_name != nullptr)
-      // {
-      //   publisher.Advertisement().LocalName(winrt::to_hstring(*local_name));
-      // }
-
-      // Adding Services throws Invalid Args Error..
-      // for (const auto &service : services)
-      // {
-      //   publisher.Advertisement().ServiceUuids().Append(uuid_to_guid(std::get<std::string>(service)));
-      // }
 
       if (manufacturer_data != nullptr)
       {

--- a/windows/ble_peripheral_plugin.h
+++ b/windows/ble_peripheral_plugin.h
@@ -83,6 +83,10 @@ namespace ble_peripheral
 
         // BluetoothLe
         Radio bluetoothRadio{nullptr};
+        std::optional<BluetoothAdapter> adapter;
+        BluetoothLEAdvertisementPublisher publisher{nullptr};
+
+        void Publisher_StatusChanged(BluetoothLEAdvertisementPublisher const &sender, IInspectable const &args);
 
         winrt::fire_and_forget InitializeAdapter();
         winrt::fire_and_forget AddServiceAsync(const BleService &service);
@@ -94,6 +98,7 @@ namespace ble_peripheral
         RadioState oldRadioState = RadioState::Unknown;
         winrt::event_revoker<IRadio> radioStateChangedRevoker;
         std::string ParseBluetoothClientId(hstring clientId);
+        std::string ParseLEAdvertisementStatus(BluetoothLEAdvertisementPublisherStatus status);
 
         GattCharacteristicObject *FindGattCharacteristicObject(std::string characteristicId);
 

--- a/windows/ble_peripheral_plugin.h
+++ b/windows/ble_peripheral_plugin.h
@@ -83,7 +83,7 @@ namespace ble_peripheral
 
         // BluetoothLe
         Radio bluetoothRadio{nullptr};
-        std::optional<BluetoothAdapter> adapter;
+        BluetoothAdapter adapter{nullptr};
         BluetoothLEAdvertisementPublisher publisher{nullptr};
 
         void Publisher_StatusChanged(BluetoothLEAdvertisementPublisher const &sender, IInspectable const &args);
@@ -108,7 +108,6 @@ namespace ble_peripheral
         winrt::fire_and_forget ReadRequestedAsync(GattLocalCharacteristic const &, GattReadRequestedEventArgs args);
         winrt::fire_and_forget WriteRequestedAsync(GattLocalCharacteristic const &, GattWriteRequestedEventArgs args);
         std::string ParseBluetoothError(BluetoothError error);
-        bool AreAllServicesStarted();
 
         // BlePeripheralChannel
         std::optional<FlutterError> Initialize();


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced Bluetooth advertisement handling for Windows platform.

- Improved error handling and logging for BLE operations.

- Refactored code to remove redundant checks and improve readability.

- Updated example app to use simplified manufacturer data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_peripheral_plugin.cpp</strong><dd><code>Refactor and enhance BLE advertisement logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/ble_peripheral_plugin.cpp

<li>Enhanced Bluetooth adapter initialization and advertisement logic.<br> <li> Added error handling for advertisement and service operations.<br> <li> Refactored redundant methods and improved logging.<br> <li> Introduced <code>Publisher_StatusChanged</code> for advertisement status updates.


</details>


  </td>
  <td><a href="https://github.com/Navideck/ble_peripheral/pull/4/files#diff-6a3f719ebcd748d2a7d3e59055362d3f91d2805f560189a36b27ef50073e69eb">+165/-84</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home_controller.dart</strong><dd><code>Update example app with simplified BLE data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home_controller.dart

<li>Simplified manufacturer data for BLE advertisement.<br> <li> Removed redundant manufacturer data definition.


</details>


  </td>
  <td><a href="https://github.com/Navideck/ble_peripheral/pull/4/files#diff-5864db25309e164a3497d7558ed023c738517ae981c551a0494493eb2c38be68">+4/-24</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ble_peripheral_plugin.h</strong><dd><code>Add BLE advertisement status methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/ble_peripheral_plugin.h

<li>Added new methods for advertisement status parsing.<br> <li> Introduced <code>Publisher_StatusChanged</code> method declaration.<br> <li> Removed unused <code>AreAllServicesStarted</code> method.


</details>


  </td>
  <td><a href="https://github.com/Navideck/ble_peripheral/pull/4/files#diff-587a9750f9618e2bb8c222c55cc9493c79b9f08ed706a58d4c2c539648e1d00f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information